### PR TITLE
changes to use Atom API 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.3.1 - Changes to Atom 1.0 API
+* Changes .editor to .atom-text-editor to comply with new 1.0 API
+
 ## 0.1.0 - First Release
 * Basic ERB snippets created
 * ERB tags loop created

--- a/keymaps/erb-snippets.cson
+++ b/keymaps/erb-snippets.cson
@@ -7,5 +7,5 @@
 
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
-'.editor':
+'.atom-text-editor':
   "cmd-shift-,": 'erb-snippets:erb_tags'

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "erb-snippets",
   "main": "./lib/erb-snippets",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Useful snippets and hotkeys for ERB templates.",
   "activationEvents": [
     "erb-snippets:erb_tags"


### PR DESCRIPTION
I updates `.editor` to `.atom-text-editor` within `keymaps/erb-snippets.cson` in order to get rid of the deprecation warning message in Atom.